### PR TITLE
Use San Francisco everywhere

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -4,7 +4,7 @@
 <meta name='viewport' content='width=device-width, initial-scale=1'>
 <meta name='description' content='CSS calculator for bulletproof form and button styles that always line up'>
 <style>
-body{font-family:-apple-system,sans-serif;margin:0}
+body{font-family:-apple-system,BlinkMacSystemFont,sans-serif;margin:0}
 input[type=number]{-moz-appearance:textfield!important}
 .px2{padding-left:16px;padding-right:16px}
 @media screen and (min-width:32em) {

--- a/src/Css.js
+++ b/src/Css.js
@@ -53,7 +53,7 @@ const css = `
       marginBottom: 48
     },
     pre: {
-      fontFamily: 'Menlo, monospace',
+      fontFamily: `'SFMono-Regular', Menlo, monospace`,
       fontSize: 12,
       lineHeight: 1.375,
       padding: 0,
@@ -70,4 +70,3 @@ const css = `
 }
 
 export default Css
-


### PR DESCRIPTION
The current `font-family` declaration will show San Francisco in Safari, but still Helvetica for Chrome users, and Menlo for the code. I've updated this to use `BlinkMacSystemFont` for San Francisco in Chrome, and if installed on one's system, SF Mono for the code.

<img width="1052" alt="screen shot 2016-06-29 at 10 58 15 am" src="https://cloud.githubusercontent.com/assets/5074763/16457140/6a280b9a-3de8-11e6-9901-54822b28a3d6.png">
