### PR TITLE
Copy the CSS to your clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
+    "clipboard": "^1.5.12",
     "gh-pages": "^0.11.0",
     "html-loader": "^0.4.3",
     "json-loader": "^0.5.4",

--- a/src/Button.js
+++ b/src/Button.js
@@ -3,6 +3,7 @@ import { hcss } from 'jsxcss'
 
 const Button = ({
   text,
+  style,
   ...props
 }) => {
   const sx = {
@@ -16,6 +17,7 @@ const Button = ({
     cursor: 'pointer',
     appearance: 'none',
     opacity: .5,
+    ...style,
     ':hover': {
       opacity: 1
     }

--- a/src/Button.js
+++ b/src/Button.js
@@ -3,7 +3,7 @@ import { hcss } from 'jsxcss'
 
 const Button = ({
   text,
-  onclick
+  ...props
 }) => {
   const sx = {
     display: 'inline-block',
@@ -24,11 +24,10 @@ const Button = ({
   return (
     <button
       style={sx}
-      onclick={onclick}>
+      {...props}>
       {text}
     </button>
   )
 }
 
 export default Button
-

--- a/src/ClipboardButton.js
+++ b/src/ClipboardButton.js
@@ -3,7 +3,7 @@ import { hcss } from 'jsxcss'
 import Button from './Button'
 import Clipboard from 'clipboard'
 
-const ClipboardButton = ({ css }) => {
+const ClipboardButton = () => {
   const button = Button({
     text: 'Copy to Clipboard',
     id: 'copy',

--- a/src/ClipboardButton.js
+++ b/src/ClipboardButton.js
@@ -1,0 +1,21 @@
+
+import { hcss } from 'jsxcss'
+import Button from './Button'
+import Clipboard from 'clipboard'
+
+const ClipboardButton = ({ css }) => {
+  const button = Button({
+    text: 'Copy to Clipboard',
+    id: 'copy'
+  })
+
+  new Clipboard(button, {
+    target: () => {
+      return document.getElementById('css')
+    }
+  })
+
+  return button
+}
+
+export default ClipboardButton

--- a/src/ClipboardButton.js
+++ b/src/ClipboardButton.js
@@ -6,7 +6,12 @@ import Clipboard from 'clipboard'
 const ClipboardButton = ({ css }) => {
   const button = Button({
     text: 'Copy to Clipboard',
-    id: 'copy'
+    id: 'copy',
+    style: {
+      border: '1px solid #111',
+      borderRadius: 4,
+      marginTop: 8
+    }
   })
 
   new Clipboard(button, {

--- a/src/Css.js
+++ b/src/Css.js
@@ -66,7 +66,7 @@ const css = `
     <section style={sx.root}>
       {Heading({ text: 'CSS' })}
       <pre style={sx.pre} id='css'>{css}</pre>
-      {ClipboardButton({ css })}
+      {ClipboardButton()}
     </section>
   )
 }

--- a/src/Css.js
+++ b/src/Css.js
@@ -1,7 +1,8 @@
 
 import { hcss } from 'jsxcss'
-import Heading from './Heading'
 import { padding } from './store'
+import Heading from './Heading'
+import ClipboardButton from './ClipboardButton'
 
 const Css = ({
   lineHeight,
@@ -64,7 +65,8 @@ const css = `
   return (
     <section style={sx.root}>
       {Heading({ text: 'CSS' })}
-      <pre style={sx.pre}>{css}</pre>
+      <pre style={sx.pre} id='css'>{css}</pre>
+      {ClipboardButton({ css })}
     </section>
   )
 }


### PR DESCRIPTION
After generating your input/button styles with Formula, you need to copy the CSS over to your project, so this PR adds a button you can click to automatically copy the CSS to your clipboard. It uses [clipboard.js](https://clipboardjs.com/) so it works in Chrome and Safari without Flash.

Note: I've added a few custom styles to the button so it's not just grey/black text.

<img width="331" alt="screen shot 2016-07-01 at 1 29 06 pm" src="https://cloud.githubusercontent.com/assets/5074763/16531078/8be0949c-3f90-11e6-89f9-dc8c0c438a53.png">
